### PR TITLE
Change representation to be compatible with key-value-coding

### DIFF
--- a/test/cauterize_schema_test.erl
+++ b/test/cauterize_schema_test.erl
@@ -5,22 +5,22 @@
 -include_lib("eunit/include/eunit.hrl").
 
 roundtrip_test() ->
-    I0 = {instance, array, somearray, [1, 2, 3, 4, 5, 6, 7, 8]},
+    I0 = [{somearray, [1, 2, 3, 4, 5, 6, 7, 8]}],
     {ok, O0} = erlang_test:encode(I0),
     ?assertEqual({ok, I0}, erlang_test:decode(O0, somearray)),
-    I1 = {instance, vector, somevector, [1, 2, 3, 4, 5]},
+    I1 = [{somevector, [1, 2, 3, 4, 5]}],
     {ok, O1} = erlang_test:encode(I1),
     ?assertEqual({ok, I1}, erlang_test:decode(O1, somevector)),
-    I2 = {instance, record, arecord, [{z, [10, 11, 12, 13]}, {a, -1}, {d, [{a, 1}, {d, [{a, 0}, {b, 1}]}]}]},
+    I2 = [{arecord, [{z, [10, 11, 12, 13]}, {a, -1}, {d, [{a, 1}, {d, [{a, 0}, {b, 1}]}]}]}],
     {ok, O2} = erlang_test:encode(I2),
     ?assertEqual({ok, I2}, erlang_test:decode(O2, arecord)),
-    I3 = {instance, union, a_union, {c, 99}},
+    I3 = [{a_union, {c, 99}}],
     {ok, O3} = erlang_test:encode(I3),
     ?assertEqual({ok, I3}, erlang_test:decode(O3, a_union)),
-    I4 = {instance, union, a_union, e},
+    I4 = [{a_union, e}],
     {ok, O4} = erlang_test:encode(I4),
     ?assertEqual({ok, I4}, erlang_test:decode(O4, a_union)),
-    I5 = {instance, combination, a_combination, [{a, 223372036854775808}, {b, -99}, d]},
+    I5 = [{a_combination, [{a, 223372036854775808}, {b, -99}, d]}],
     {ok, O5} = erlang_test:encode(I5),
     ?assertEqual({ok, I5}, erlang_test:decode(O5, a_combination)),
 


### PR DESCRIPTION
```
1> kvc:path("arecord.d.d", [{arecord, [{z, [10, 11, 12, 13]}, {a, -1}, {d, [{a, 1}, {d, [{a, 0}, {b, 1}]}]}]}]).
[{a,0},{b,1}]
2> kvc:path("arecord.d.d.b", [{arecord, [{z, [10, 11, 12, 13]}, {a, -1}, {d, [{a, 1}, {d, [{a, 0}, {b, 1}]}]}]}]).
1
```
